### PR TITLE
#4 Fixes error accessing CAS attributes during REST call

### DIFF
--- a/src/main/java/org/sonar/plugins/cas/CasAuthenticator.java
+++ b/src/main/java/org/sonar/plugins/cas/CasAuthenticator.java
@@ -21,6 +21,7 @@ package org.sonar.plugins.cas;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import org.jasig.cas.client.authentication.AttributePrincipal;
 import org.jasig.cas.client.validation.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,7 +115,8 @@ public final class CasAuthenticator extends Authenticator {
         try {
             CasRestClient crc = new CasRestClient(casServerUrlPrefix, serviceUrl);
             String ticket = crc.createServiceTicket(context.getUsername(), context.getPassword());
-            Assertion assertion = createTicketValidator().validate(ticket, serviceUrl);
+            Cas30ProxyTicketValidator validator = new Cas30ProxyTicketValidator(getCasServerUrlPrefix());
+            Assertion assertion = validator.validate(ticket, serviceUrl);
             if (assertion != null) {
                 LOG.info("successful authentication via cas rest api");
                 // add assertions to request attribute, in order to process groups with the CasGroupsProvider
@@ -140,9 +142,10 @@ public final class CasAuthenticator extends Authenticator {
 
 
         // populate user details from assertion
-        Map<String, Object> attributes = assertion.getAttributes();
+        AttributePrincipal principal = assertion.getPrincipal();
 
-        user.setUserId(assertion.getPrincipal().getName());
+        Map<String, Object> attributes = principal.getAttributes();
+        user.setUserId(principal.getName());
 
         String displayName = attributeSettings.getDisplayName(attributes);
         if (!Strings.isNullOrEmpty(displayName)) {

--- a/src/main/java/org/sonar/plugins/cas/CasGroupsProvider.java
+++ b/src/main/java/org/sonar/plugins/cas/CasGroupsProvider.java
@@ -49,7 +49,7 @@ class CasGroupsProvider extends ExternalGroupsProvider {
     Assertion assertion = (Assertion) context.getRequest().getAttribute(Assertion.class.getName());
     Preconditions.checkState(assertion != null, "could not find assertions in the request");
 
-    Set<String> groups = settings.getGroups(assertion.getAttributes());
+    Set<String> groups = settings.getGroups(assertion.getPrincipal().getAttributes());
     if (groups == null) {
       groups = Collections.emptySet();
     }


### PR DESCRIPTION
The wrong attribute was used to propagate the CAS attributes. This
commit uses the principal whose attributes are properly maintained with
the CAS ticket values.