### PR TITLE
#15 Handle authentication only on the server sides

### DIFF
--- a/src/main/java/org/sonar/plugins/cas/CasPlugin.java
+++ b/src/main/java/org/sonar/plugins/cas/CasPlugin.java
@@ -20,7 +20,10 @@
 
 package org.sonar.plugins.cas;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonar.api.Plugin;
+import org.sonar.api.SonarQubeSide;
 import org.sonar.plugins.cas.logout.CasSonarSignOutInjectorFilter;
 import org.sonar.plugins.cas.logout.LogoutHandler;
 import org.sonar.plugins.cas.session.CasSessionStoreFactory;
@@ -43,12 +46,19 @@ import java.util.List;
  */
 public final class CasPlugin implements Plugin {
 
+    private static final Logger LOG = LoggerFactory.getLogger(CasPlugin.class);
+
     public CasPlugin() {
         // called by SonarQube during initializing
     }
 
     public void define(Context context) {
-        context.addExtensions(collectExtensions());
+        SonarQubeSide sonarQubeSide = context.getRuntime().getSonarQubeSide();
+        if (sonarQubeSide == SonarQubeSide.SERVER) {
+            context.addExtensions(collectExtensions());
+        } else {
+            LOG.info("skip all extensions, because we are on the {} side", sonarQubeSide);
+        }
     }
 
     List<Object> collectExtensions() {


### PR DESCRIPTION
There are 3 internal SonarQube components in which a Plugin can act.
Authentication must only take place on the Server side because we
heavily rely on HTTP request and response communication which is moot
outside that component.

This commit binds sonar extensions only if we are on the server side of
SonarQube.

Resolves #15 