### PR TITLE
#13 Decouple Javascript event registering for better local logout

### DIFF
--- a/docker/config/cas.properties
+++ b/docker/config/cas.properties
@@ -13,7 +13,7 @@ cas.authn.attributeRepository.merger=REPLACE
 # Those values are only strings
 cas.authn.attributeRepository.stub.attributes.mail=tricia.mcmillan@hitchhiker.com
 cas.authn.attributeRepository.stub.attributes.displayName=Tricia McMillan
-cas.authn.attributeRepository.stub.attributes.groups=admin
+cas.authn.attributeRepository.stub.attributes.groups=sonar-administrators
 
 cas.authn.accept.users=trillian::secret,dent::secret,admin::secret
 

--- a/src/main/java/org/sonar/plugins/cas/logout/CasSonarSignOutInjectorFilter.java
+++ b/src/main/java/org/sonar/plugins/cas/logout/CasSonarSignOutInjectorFilter.java
@@ -96,7 +96,7 @@ public final class CasSonarSignOutInjectorFilter extends ServletFilter {
         String casLogoutUrl = getCasLogoutUrl();
         String javaScriptToInject = builder.toString().replace(CASLOGOUTURL_PLACEHOLDER, casLogoutUrl);
         response.getOutputStream().println(javaScriptToInject);
-        response.getOutputStream().println("window.onload = logoutHandler;");
+        response.getOutputStream().println("window.onload = logoutMenuHandler;");
         response.getOutputStream().println("</script>");
     }
 

--- a/src/main/resources/casLogoutUrl.js
+++ b/src/main/resources/casLogoutUrl.js
@@ -1,5 +1,24 @@
+function logoutMenuHandler() {
+    var menuHandlerTimer = setInterval(function () {
+        var elem1 = document.getElementById('global-navigation');
+        if (!elem1) {
+            return;
+        }
+        var elem2 = elem1.getElementsByClassName('js-user-authenticated')[0];
+        if (!elem2) {
+            return;
+        }
+        var elem3 = elem2.getElementsByTagName('a')[0];
+        if (elem3) {
+            elem3.addEventListener('click', logoutHandler);
+
+            clearInterval(menuHandlerTimer);
+        }
+    }, 250);
+}
+
 function logoutHandler() {
-    var timer = setInterval(function () {
+    var logoutHandlerTimer = setInterval(function () {
         var elem1 = document.getElementById('global-navigation');
         if (! elem1) { return; }
         var elem2 = elem1.getElementsByClassName('js-user-authenticated')[0];
@@ -10,10 +29,10 @@ function logoutHandler() {
         if (elem4) {
             elem4.addEventListener('click', function () {
                 window.location.href = 'CASLOGOUTURL';
-                return true;
+                return false;
             });
-            clearInterval(timer);
+            clearInterval(logoutHandlerTimer);
         }
 
-    }, 500);
+    }, 100);
 }

--- a/src/main/resources/casLogoutUrl.js
+++ b/src/main/resources/casLogoutUrl.js
@@ -27,8 +27,9 @@ function logoutHandler() {
         if (! elem3) { return; }
         var elem4 = elem3.getElementsByTagName('a')[1];
         if (elem4) {
-            elem4.addEventListener('click', function () {
+            elem4.addEventListener('click', function (event) {
                 window.location.href = 'CASLOGOUTURL';
+                event.stopImmediatePropagation();
                 return false;
             });
             clearInterval(logoutHandlerTimer);


### PR DESCRIPTION
The injected Javascript which logs out the user locally from SonarQube
stopped the event registering once the menu was clicked. Since the
logout link is removed from the DOM when the user closes the menu, a
proper logout is no longer possible.

This commit decouples this behaviour so that now two event handlers are
registered:

1. A click handler for the menu itself
2. A click handler for the logout link

Every time the menu is opened, the logout click handler will be
newly registered so that this handler works for each time, the menu is
opened.

Resolves #13