### PR TITLE
Fix error 'Could not create cookie. Context path must not be empty…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.cloudogu.sonar</groupId>
     <artifactId>sonar-cas-plugin</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <packaging>sonar-plugin</packaging>
 
     <description>CAS Support for SonarQube</description>

--- a/src/main/java/org/sonar/plugins/cas/LoginHandler.java
+++ b/src/main/java/org/sonar/plugins/cas/LoginHandler.java
@@ -98,7 +98,9 @@ public class LoginHandler {
         }
 
         Set<String> groups = attributeSettings.getGroups(attributes);
-        builder = builder.setGroups(groups);
+        if (!groups.isEmpty()) {
+            builder = builder.setGroups(groups);
+        }
 
         return builder.build();
     }
@@ -121,6 +123,9 @@ public class LoginHandler {
     }
 
     private void removeRedirectCookie(HttpServletResponse response, String contextPath) {
+        if (StringUtils.isBlank(contextPath)) {
+            contextPath = "/";
+        }
         Cookie cookie = Cookies.createDeletionCookie(COOKIE_NAME_URL_AFTER_CAS_REDIRECT, contextPath);
 
         response.addCookie(cookie);

--- a/src/main/java/org/sonar/plugins/cas/util/HttpStreams.java
+++ b/src/main/java/org/sonar/plugins/cas/util/HttpStreams.java
@@ -94,17 +94,24 @@ public final class HttpStreams {
      */
     public static void saveRequestedURLInCookie(HttpServletRequest request, HttpServletResponse response, int maxCookieAge) {
         String originalURL = HttpStreams.getRequestUrlWithQueryParameters(request);
+        String contextPath = request.getContextPath();
+
+        if(StringUtils.isBlank(contextPath)){
+            contextPath = "/";
+        }
+
         LOG.debug("found original URL {}", originalURL);
-        LOG.debug("using context path {}", request.getContextPath());
+        LOG.debug("using context path {}", contextPath);
+
 
         Cookie cookie = new Cookies.HttpOnlyCookieBuilder()
                 .name(COOKIE_NAME_URL_AFTER_CAS_REDIRECT)
                 .value(originalURL)
                 .maxAgeInSecs(maxCookieAge)
-                .contextPath(request.getContextPath())
+                .contextPath(contextPath)
                 .build();
 
-        LOG.debug("set cookie with context path {}", request.getContextPath());
+        LOG.debug("set cookie with context path {}", contextPath);
         response.addCookie(cookie);
     }
 }

--- a/src/test/java/org/sonar/plugins/cas/util/HttpStreamsTest.java
+++ b/src/test/java/org/sonar/plugins/cas/util/HttpStreamsTest.java
@@ -113,4 +113,25 @@ public class HttpStreamsTest {
         verify(request, times(2)).getQueryString();
         verify(response).addCookie(any());
     }
+
+
+    @Test
+    public void saveRequestedURLInCookieEmptyContext() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        String originalURL = "http://sonar.url.com/somePageWhichIsNotLogin";
+        when(request.getRequestURL()).thenReturn(new StringBuffer(originalURL));
+        when(request.getContextPath()).thenReturn("");
+        // getRequestURL does NOT return query params. Kinda important for called sonar URLs
+        when(request.getQueryString()).thenReturn("project=Das+&amp;Uuml;ber+Project&file=src/main/com/cloudogu/App.java");
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        HttpStreams.saveRequestedURLInCookie(request, response, 300);
+
+        verify(request).getRequestURL();
+        // Cookie is a crappy class that does not allow equals or hashcode, so we test the number of invocations of
+        // getParameterMap. If it was only once, it would not have jumped into urlEncodeQueryParameters()
+        verify(request, times(2)).getQueryString();
+        verify(response).addCookie(any());
+    }
 }


### PR DESCRIPTION
Hi there, 

I really like the sonar plugin and it helps us a lot. 
Thank you very much for contributing so great plugin. 
BTW, I have fixed some bugs, hope it could make life better.

1. Fix error 'Could not create cookie. Context path must not be empty.' when context path is unset or to '/'
2. Do not update user group when group attribute is not returned by cas server
3. version upgrade to 2.0.2

