### PR TITLE
fix redirect if user is not authenticated #32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]
 
+### Fixed
+- Fixes defective redirect behaviour for repeated unauthenticated requests (#32)
+  - this fix also allows unauthenticated requests for static resources
+
 [v3.0.0](https://github.com/cloudogu/sonar-cas-plugin/releases/tag/v3.0.0) - 2021-06-02
 
 Breaking change ahead.

--- a/docs/architecture_de.md
+++ b/docs/architecture_de.md
@@ -140,8 +140,7 @@ In Bezug auf `ServletFilter`-Komponenten darf jeder Filter die angegebene `Filte
 
 ### CasIdentityProvider für browserbasierte Anfragen
 
-Der `CasIdentityProvider` kümmert sich um das Ein- und Ausloggen. Das Einloggen ist der bei weitem komplexere Prozess von beiden
-der oben beschrieben ist.
+Der `CasIdentityProvider` kümmert sich um das Ein- und Ausloggen. Das Einloggen ist der bei weitem komplexere Prozess von beiden der oben beschrieben ist.
 
 ### CasAuthenticator für REST-basierte Anfragen
 
@@ -151,6 +150,8 @@ Der `CasAuthenticator` kümmert sich um HTTP-API-Aufrufe in Richtung SonarQube.
 
 Der `ForceCasLoginFilter` prüft bei jeder Anfrage, ob die Anfrage erlaubt ist, indem er den Session Store mit dem
 JWT aus der Anfrage des Benutzers.
+
+Anfragen auf statischen Ressourcen werden erlaubt, da diese u. U. asynchron vor einer Authentifizierung ausgeführt werden können. Innerhalb des Authentifizierungsprozesses werden Benutzende anhand des Feldes "LOGIN" erkannt. Ein leeres Feld oder ein Login mit dem Wert `-` bedeutet, dass noch keine Authentifizierung stattgefunden hat.
 
 ### FileSessionStore
 

--- a/docs/architecture_en.md
+++ b/docs/architecture_en.md
@@ -152,6 +152,8 @@ The `CasAuthenticator` takes care of HTTP-API calls toward SonarQube.
 The `ForceCasLoginFilter` checks for every request if the request is permitted by checking the session store with the
 JWT from the user's request.
 
+Requests on static resources are allowed, since these may be executed asynchronously before authentication. Within the authentication process, users are recognized by the "LOGIN" field. An empty field or a login with the value `-` means that no authentication has taken place yet.
+
 ### FileSessionStore
 
 The `FileSessionStore` is an implementation of a session store. The session store maintains a white-/blacklist of all

--- a/src/main/java/org/sonar/plugins/cas/ForceCasLoginFilter.java
+++ b/src/main/java/org/sonar/plugins/cas/ForceCasLoginFilter.java
@@ -54,8 +54,8 @@ public class ForceCasLoginFilter extends ServletFilter {
     /**
      * Array of request URLS that should not be redirected to the login page.
      */
-    private static final List<String> WHITE_LIST = Arrays.asList(
-            "/sessions/", "/api/", "/batch_bootstrap/", "/deploy/", "/batch");
+    private static final List<String> ALLOW_LIST = Arrays.asList(
+            "/js/", "/images/", "/favicon.ico", "/sessions/", "/api/", "/batch_bootstrap/", "/deploy/", "/batch");
 
     private final Configuration configuration;
     private LogoutHandler logoutHandler;
@@ -77,7 +77,7 @@ public class ForceCasLoginFilter extends ServletFilter {
         String requestedURL = request.getRequestURL().toString();
         int maxRedirectCookieAge = getMaxCookieAge(configuration);
 
-        if (isInWhiteList(request.getServletPath()) || isAuthenticated(request)) {
+        if (isInAllowList(request.getServletPath()) || isAuthenticated(request)) {
             LOG.debug("Found permitted request to {}", requestedURL);
 
             if (logoutHandler.isUserLoggedOutAndLogsInAgain(request)) {
@@ -101,7 +101,7 @@ public class ForceCasLoginFilter extends ServletFilter {
     }
 
     private void redirectToLogin(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        LOG.debug("Redirecting to login page {}", request.getRequestURL(), SONAR_LOGIN_URL_PATH);
+        LOG.debug("Redirecting to login page {} -> {}", request.getRequestURL(), SONAR_LOGIN_URL_PATH);
 
         response.sendRedirect(request.getContextPath() + SONAR_LOGIN_URL_PATH);
     }
@@ -109,7 +109,8 @@ public class ForceCasLoginFilter extends ServletFilter {
     private boolean isAuthenticated(HttpServletRequest request) {
         // https://github.com/SonarSource/sonarqube/blob/9973bacbfa4a945e509bf1b574d7e5aae4ba155a/server/sonar-server/src/main/java/org/sonar/server/authentication/UserSessionInitializer.java#L138
         String login = StringUtils.defaultString((String) request.getAttribute("LOGIN"));
-        return !"-".equals(login);
+        LOG.debug("login value: {}", login);
+        return !"-".equals(login) && !"".equals(login);
     }
 
     /**
@@ -118,12 +119,12 @@ public class ForceCasLoginFilter extends ServletFilter {
      * @param entry Entry to look for in white list.
      * @return true if found, false otherwise.
      */
-    private boolean isInWhiteList(final String entry) {
+    private boolean isInAllowList(final String entry) {
         if (null == entry) {
             return false;
         }
 
-        for (final String item : WHITE_LIST) {
+        for (final String item : ALLOW_LIST) {
             if (entry.contains(item)) {
                 return true;
             }

--- a/src/test/java/org/sonar/plugins/cas/ForceCasLoginFilterTest.java
+++ b/src/test/java/org/sonar/plugins/cas/ForceCasLoginFilterTest.java
@@ -17,7 +17,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 import static org.sonar.plugins.cas.AuthTestData.getJwtToken;
 
@@ -44,7 +43,7 @@ public class ForceCasLoginFilterTest {
         Cookie httpOnlyCookie = createJwtCookie(jwtCookieDoughContent);
         Cookie[] cookies = {httpOnlyCookie};
         when(request.getCookies()).thenReturn(cookies);
-        when(request.getRequestURL()).thenReturn(new StringBuffer("http://sonar.url.com/somePageWhichIsNotLogin"));
+        when(request.getRequestURL()).thenReturn(new StringBuffer("http://sonar.url.com/sonar/somePageWhichIsNotLogin"));
         when(request.getContextPath()).thenReturn("/sonar");
 
         HttpServletResponse response = mock(HttpServletResponse.class);
@@ -52,12 +51,11 @@ public class ForceCasLoginFilterTest {
 
         sut.doFilter(request, response, filterChain);
 
-        VerificationMode noInteraction = times(0);
-        verify(filterChain).doFilter(request, response);
-        verify(response, noInteraction).sendRedirect(any());
-        verify(response, noInteraction).addCookie(any());
-        verify(store, noInteraction).invalidateJwt(anyString());
-        verify(response, never()).sendRedirect(any());
+        VerificationMode singleInteraction = times(1);
+        verifyZeroInteractions(filterChain);
+        verify(response, singleInteraction).sendRedirect(any());
+        verify(response, singleInteraction).addCookie(any());
+        verify(store, never()).invalidateJwt(anyString());
     }
 
     private Cookie createJwtCookie(String jwtCookieDoughContent) {


### PR DESCRIPTION
- static resources have to be allowlisted so they will be procesed by the default filters and were not stored in redirect cookie
- a wrong redirect of the resources will lead to blocked requests due to mixed content

Resolves #32 