### PR TITLE
Bugfix/34 fix empty cas group replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]
 
+### Fixed
+- Fixes defective CAS group replication when the group list was empty (#34)
+
 [v3.0.1](https://github.com/cloudogu/sonar-cas-plugin/releases/tag/v3.0.1) - 2021-06-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]
 
+Breaking change ahead.
+
 ### Fixed
 - Fixes defective CAS group replication when the group list was empty (#34)
+  - The group replication behaviour now defaults to CAS group replication.
+  - The `sonar-property` key `sonar.cas.groupReplication` must be set to `sonarqube` if local SonarQube groups are preferred.
 
 [v3.0.1](https://github.com/cloudogu/sonar-cas-plugin/releases/tag/v3.0.1) - 2021-06-03
 

--- a/sonar-home/conf/sonar.properties
+++ b/sonar-home/conf/sonar.properties
@@ -396,8 +396,8 @@ sonar.cas.sessionStore.cleanUpIntervalInSeconds = 1800
 # sonar.cas.sendGateway
 
 # Specifies how SonarQube groups should be replicated. A value of "CAS" always overwrites the user's local groups with
-# the group provided by CAS upon UI log-in. The user's local groups will be untouched with other values.
-# Defaults to the empty string.
+# the group provided by CAS upon UI log-in. The user's local groups will be untouched, f. i. with the value "sonarqube".
+# Defaults to "CAS".
 sonar.cas.groupReplication = CAS
 sonar.cas.rolesAttributes = groups
 sonar.cas.fullNameAttribute = displayName

--- a/sonar-home/conf/sonar.properties
+++ b/sonar-home/conf/sonar.properties
@@ -395,6 +395,10 @@ sonar.cas.sessionStore.cleanUpIntervalInSeconds = 1800
 # Specifies whether gateway=true should be sent to the CAS server. Default is false.
 # sonar.cas.sendGateway
 
+# Specifies how SonarQube groups should be replicated. A value of "CAS" always overwrites the user's local groups with
+# the group provided by CAS upon UI log-in. The user's local groups will be untouched with other values.
+# Defaults to the empty string.
+sonar.cas.groupReplication = CAS
 sonar.cas.rolesAttributes = groups
 sonar.cas.fullNameAttribute = displayName
 sonar.cas.eMailAttribute = mail

--- a/src/main/java/org/sonar/plugins/cas/LoginHandler.java
+++ b/src/main/java/org/sonar/plugins/cas/LoginHandler.java
@@ -35,6 +35,7 @@ import static org.sonar.plugins.cas.util.Cookies.COOKIE_NAME_URL_AFTER_CAS_REDIR
 @ServerSide
 public class LoginHandler {
     private static final Logger LOG = LoggerFactory.getLogger(LoginHandler.class);
+    private static final String GROUP_REPLICATION_CAS = "CAS";
 
     private final Configuration configuration;
     private final CasAttributeSettings attributeSettings;
@@ -98,7 +99,7 @@ public class LoginHandler {
         }
 
         Set<String> groups = attributeSettings.getGroups(attributes);
-        if (!groups.isEmpty()) {
+        if (GROUP_REPLICATION_CAS.equals(getGroupReplicationMode())) {
             builder = builder.setGroups(groups);
         }
 
@@ -140,5 +141,9 @@ public class LoginHandler {
         String sonarUrl = SonarCasProperties.SONAR_SERVER_URL.mustGetString(configuration);
         // SonarQube recognizes the Identity Provider by the identifier in the URL. `sonarqube` corresponds to the value from getKey()
         return sonarUrl + "/sessions/init/sonarqube";
+    }
+
+    private String getGroupReplicationMode() {
+        return SonarCasProperties.GROUP_REPLICATE.getString(configuration, "");
     }
 }

--- a/src/main/java/org/sonar/plugins/cas/LoginHandler.java
+++ b/src/main/java/org/sonar/plugins/cas/LoginHandler.java
@@ -144,6 +144,6 @@ public class LoginHandler {
     }
 
     private String getGroupReplicationMode() {
-        return SonarCasProperties.GROUP_REPLICATE.getString(configuration, "");
+        return SonarCasProperties.GROUP_REPLICATE.getString(configuration, GROUP_REPLICATION_CAS);
     }
 }

--- a/src/main/java/org/sonar/plugins/cas/LoginHandler.java
+++ b/src/main/java/org/sonar/plugins/cas/LoginHandler.java
@@ -100,6 +100,8 @@ public class LoginHandler {
 
         Set<String> groups = attributeSettings.getGroups(attributes);
         if (GROUP_REPLICATION_CAS.equals(getGroupReplicationMode())) {
+            // currently SonarQube only sets groups which already exists in the local group database.
+            // Thus, new CAS groups will never be added unless manually added in SonarQube.
             builder = builder.setGroups(groups);
         }
 

--- a/src/main/java/org/sonar/plugins/cas/util/SonarCasProperties.java
+++ b/src/main/java/org/sonar/plugins/cas/util/SonarCasProperties.java
@@ -48,6 +48,16 @@ public enum SonarCasProperties {
      */
     CAS_SERVER_URL_PREFIX("sonar.cas.casServerUrlPrefix", SonarPropertyType.STRING),
     /**
+     * Specifies how SonarQube groups should be replicated.
+
+     * <p>A value of <code>CAS</code> always overwrites the user's
+     * local groups with the group provided by CAS upon UI log-in. The user's local groups will be untouched with other
+     * values.</p>
+     *
+     * Defaults to the empty string.
+     */
+    GROUP_REPLICATE("sonar.cas.groupReplication", SonarPropertyType.STRING),
+    /**
      * Sonar server root URL, without ending slash.
      */
     SONAR_SERVER_URL("sonar.cas.sonarServerUrl", SonarPropertyType.STRING),

--- a/src/main/java/org/sonar/plugins/cas/util/SonarCasProperties.java
+++ b/src/main/java/org/sonar/plugins/cas/util/SonarCasProperties.java
@@ -54,7 +54,7 @@ public enum SonarCasProperties {
      * local groups with the group provided by CAS upon UI log-in. The user's local groups will be untouched with other
      * values.</p>
      *
-     * Defaults to the empty string.
+     * Defaults to "CAS".
      */
     GROUP_REPLICATE("sonar.cas.groupReplication", SonarPropertyType.STRING),
     /**


### PR DESCRIPTION
resolves #34 by making group replication configurable. The implementation favours CAS group replication, though. Either way this change implies a breaking change and should be release as v4.0.0