### PR TITLE
Bugfix/38 redirect after cas login with correct schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,38 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
-
 - Add properties key `sonar.cas.userSecureRedirectCookies` to configure the redirect cookie's `secure` flag
-  - if not configured the cookie's secure flag defaults to `true`
+   - if not configured the cookie's secure flag defaults to `true`
 
 ### Fixed
-
 - Fixed insecure redirect request after login (#39)
 
 ## [v4.1.0](https://github.com/cloudogu/sonar-cas-plugin/releases/tag/v4.1.0) - 2021-07-28
-
 ### Added
-
 - Add Proxy ticketing against SonarQube API (#36)
-  - you can find requirements and more information about this topic in the [documentation](docs/architecture_en.md)
+   - you can find requirements and more information about this topic in the [documentation](docs/architecture_en.md)
 
 ## [v4.0.0](https://github.com/cloudogu/sonar-cas-plugin/releases/tag/v4.0.0) - 2021-06-03
 
 Breaking change ahead.
 
 ### Fixed
-
 - Fixes defective CAS group replication when the group list was empty (#34)
-  - The group replication behaviour now defaults to CAS group replication.
-  - The `sonar.properties` key `sonar.cas.groupReplication` must be set to `sonarqube` if local SonarQube groups are
-    preferred.
+   - The group replication behaviour now defaults to CAS group replication.
+   - The `sonar.properties` key `sonar.cas.groupReplication` must be set to `sonarqube` if local SonarQube groups are
+     preferred.
 
 ## [v3.0.1](https://github.com/cloudogu/sonar-cas-plugin/releases/tag/v3.0.1) - 2021-06-03
 ### Fixed
 - Fixes defective redirect behaviour for repeated unauthenticated requests (#32)
-  - this fix also allows unauthenticated requests for static resources
+   - this fix also allows unauthenticated requests for static resources
 
 ## [v3.0.0](https://github.com/cloudogu/sonar-cas-plugin/releases/tag/v3.0.0) - 2021-06-02
 
@@ -45,7 +39,8 @@ Breaking change ahead.
 
 ### Changed
 - this release of Sonar-CAS-Plugin only supports SonarQube v8.9 or later (#30)
-  - user accounts which were replicated with CAS show now up without the CAS identity provider mark in the User overview
+   - user accounts which were replicated with CAS show now up without the CAS identity provider mark in the User
+     overview
 
 ### Fixed
 - switch name of security realm `cas` to `sonarqube` to ensure authentication via REST API with SonarQube 8.9 (#30)
@@ -59,11 +54,9 @@ Breaking change ahead.
 Breaking change ahead.
 
 ### Changed
-
-- Support SonarQube 7.9 LTS  
-    - In order to support Single Logout (SLO) the UI Menu 
-    - This plugin version does explicitly not work with the previous SonarQube 6.7 LTS version
+- Support SonarQube 7.9 LTS
+   - In order to support Single Logout (SLO) the UI Menu
+   - This plugin version does explicitly not work with the previous SonarQube 6.7 LTS version
 
 ### Fixed
-
 - Fixed double content rendering of non-HTML resources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[Unreleased]
+## [Unreleased]
+
+### Fixed
+
+- Fixed insecure redirect request after login (#39)
 
 ## [v4.1.0](https://github.com/cloudogu/sonar-cas-plugin/releases/tag/v4.1.0) - 2021-07-28
+
 ### Added
 
 - Add Proxy ticketing against SonarQube API (#36)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- Add properties key `sonar.cas.userSecureRedirectCookies` to configure the redirect cookie's `secure` flag
+  - if not configured the cookie's secure flag defaults to `true`
+
 ### Fixed
+
 - Fixed insecure redirect request after login (#39)
 
 ## [v4.1.0](https://github.com/cloudogu/sonar-cas-plugin/releases/tag/v4.1.0) - 2021-07-28
+
 ### Added
+
 - Add Proxy ticketing against SonarQube API (#36)
   - you can find requirements and more information about this topic in the [documentation](docs/architecture_en.md)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Fixed
-
 - Fixed insecure redirect request after login (#39)
 
 ## [v4.1.0](https://github.com/cloudogu/sonar-cas-plugin/releases/tag/v4.1.0) - 2021-07-28
-
 ### Added
-
 - Add Proxy ticketing against SonarQube API (#36)
   - you can find requirements and more information about this topic in the [documentation](docs/architecture_en.md)
 
@@ -30,7 +26,6 @@ Breaking change ahead.
     preferred.
 
 ## [v3.0.1](https://github.com/cloudogu/sonar-cas-plugin/releases/tag/v3.0.1) - 2021-06-03
-
 ### Fixed
 - Fixes defective redirect behaviour for repeated unauthenticated requests (#32)
   - this fix also allows unauthenticated requests for static resources

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,6 @@ node {
         String SonarJreImage = 'adoptopenjdk/openjdk11:jre-11.0.11_9-alpine'
         Git git = new Git(this)
 
-        catchError {
-
         stage('Checkout') {
             checkout scm
             git.clean('')
@@ -37,7 +35,7 @@ node {
 
             def scannerHome = tool name: 'sonar-scanner', type: 'hudson.plugins.sonar.SonarRunnerInstallation'
             withSonarQubeEnv {
-                Git git = new Git(this, "cesmarvin")
+                git = new Git(this, "cesmarvin")
 
                 sh "git config 'remote.origin.fetch' '+refs/heads/*:refs/remotes/origin/*'"
                 gitWithCredentials("fetch --all")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,82 +1,58 @@
 #!groovy
-@Library(['github.com/cloudogu/ces-build-lib@1.44.3'])
+@Library(['github.com/cloudogu/ces-build-lib@1.48.0'])
 import com.cloudogu.ces.cesbuildlib.*
 
-node {
+node() {
+    Git git = new Git(this, "cesmarvin")
+    git.committerName = 'cesmarvin'
+    git.committerEmail = 'cesmarvin@cloudogu.com'
+
     timestamps {
-        repositoryOwner = 'cloudogu'
-        projectName = 'sonar-cas-plugin'
-        projectPath = "/go/src/github.com/${repositoryOwner}/${projectName}/"
-        githubCredentialsId = 'sonarqube-gh'
+        properties([
+                // Keep only the last 10 build to preserve space
+                buildDiscarder(logRotator(numToKeepStr: '10')),
+                // Don't run concurrent builds for a branch, because they use the same workspace directory
+                disableConcurrentBuilds()
+        ])
 
-        def javaHome = tool 'JDK8'
-        Maven mvn = new MavenWrapper(this, javaHome)
-        // Sonar stopped support for JRE8 for its client, so for now we run the analysis in a separate container.
-        // Once the lib is upgraded to JDK11 this can be removed
-        String SonarJreImage = 'adoptopenjdk/openjdk11:jre-11.0.11_9-alpine'
-        Git git = new Git(this)
+        catchError {
 
-        stage('Checkout') {
-            checkout scm
-            git.clean('')
-        }
-
-        stage('Build') {
-            mvn 'clean install -DskipTests'
-            archive '**/target/*.jar'
-        }
-
-        stage('Unit Test') {
-            mvn 'test'
-        }
-
-        stage('SonarQube') {
-            def branch = "${env.BRANCH_NAME}"
-
-            def scannerHome = tool name: 'sonar-scanner', type: 'hudson.plugins.sonar.SonarRunnerInstallation'
-            withSonarQubeEnv {
-                git = new Git(this, "cesmarvin")
-
-                sh "git config 'remote.origin.fetch' '+refs/heads/*:refs/remotes/origin/*'"
-                gitWithCredentials("fetch --all")
-
-                if (branch == "master") {
-                    echo "This branch has been detected as the main branch."
-                    sh "${scannerHome}/bin/sonar-scanner -Dsonar.projectKey=${projectName} -Dsonar.projectName=${projectName}"
-                } else if (branch == "develop") {
-                    echo "This branch has been detected as the develop branch."
-                    sh "${scannerHome}/bin/sonar-scanner -Dsonar.projectKey=${projectName} -Dsonar.projectName=${projectName} -Dsonar.branch.name=${env.BRANCH_NAME} -Dsonar.branch.target=master  "
-                } else if (env.CHANGE_TARGET) {
-                    echo "This branch has been detected as a pull request."
-                    sh "${scannerHome}/bin/sonar-scanner -Dsonar.projectKey=${projectName} -Dsonar.projectName=${projectName} -Dsonar.branch.name=${env.CHANGE_BRANCH}-PR${env.CHANGE_ID} -Dsonar.branch.target=${env.CHANGE_TARGET} "
-                } else if (branch.startsWith("feature/") || branch.startsWith("bugfix/")) {
-                    echo "This branch has been detected as a feature branch."
-                    sh "${scannerHome}/bin/sonar-scanner -Dsonar.projectKey=${projectName} -Dsonar.projectName=${projectName} -Dsonar.branch.name=${env.BRANCH_NAME} -Dsonar.branch.target=develop"
-                } else {
-                    echo "WARNING: This branch has not been detected. Assuming a feature branch."
-                    sh "${scannerHome}/bin/sonar-scanner -Dsonar.projectKey=${projectName} -Dsonar.projectName=${projectName} -Dsonar.branch.name=${env.BRANCH_NAME} -Dsonar.branch.target=develop"
-                }
+            stage('Checkout') {
+                checkout scm
+                git.clean("")
             }
-            timeout(time: 2, unit: 'MINUTES') { // Needed when there is no webhook for example
-                def qGate = waitForQualityGate()
-                if (qGate.status != 'OK') {
-                    unstable("Pipeline unstable due to SonarQube quality gate failure")
-                }
+
+            Maven mvn = new MavenInDocker(this, "3.5.0-jdk-8")
+
+            stage('Build') {
+                setupMaven(mvn)
+                mvn 'clean compile -DskipTests'
+            }
+
+            stage('Unit Test') {
+                mvn 'test'
+            }
+        }
+
+        stage('Statical Code Analysis') {
+            def sonarQube = new SonarQube(this, [sonarQubeEnv: 'ces-sonar'])
+
+            sonarQube.analyzeWith(new MavenInDocker(this, "3.5.0-jdk-8"))
+            sonarQube.timeoutInMinutes = 4
+
+            if (!sonarQube.waitForQualityGateWebhookToBeCalled()) {
+                unstable("Pipeline unstable due to SonarQube quality gate failure")
             }
         }
     }
+
+    // Archive Unit and integration test results, if any
+    junit allowEmptyResults: true, testResults: '**/target/failsafe-reports/TEST-*.xml,**/target/surefire-reports/TEST-*.xml'
 }
 
-String repositoryOwner
-String projectName
-String projectPath
-String githubCredentialsId
-
-void gitWithCredentials(String command) {
-    withCredentials([usernamePassword(credentialsId: 'cesmarvin', usernameVariable: 'GIT_AUTH_USR', passwordVariable: 'GIT_AUTH_PSW')]) {
-        sh(
-                script: "git -c credential.helper=\"!f() { echo username='\$GIT_AUTH_USR'; echo password='\$GIT_AUTH_PSW'; }; f\" " + command,
-                returnStdout: true
-        )
+def setupMaven(mvn) {
+    if ("master".equals(env.BRANCH_NAME)) {
+        mvn.additionalArgs = "-DperformRelease"
+        currentBuild.description = mvn.getVersion()
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,84 @@
+#!groovy
+@Library(['github.com/cloudogu/ces-build-lib@1.44.3'])
+import com.cloudogu.ces.cesbuildlib.*
+
+node {
+    timestamps {
+        repositoryOwner = 'cloudogu'
+        projectName = 'sonar-cas-plugin'
+        projectPath = "/go/src/github.com/${repositoryOwner}/${projectName}/"
+        githubCredentialsId = 'sonarqube-gh'
+
+        def javaHome = tool 'JDK8'
+        Maven mvn = new MavenWrapper(this, javaHome)
+        // Sonar stopped support for JRE8 for its client, so for now we run the analysis in a separate container.
+        // Once the lib is upgraded to JDK11 this can be removed
+        String SonarJreImage = 'adoptopenjdk/openjdk11:jre-11.0.11_9-alpine'
+        Git git = new Git(this)
+
+        catchError {
+
+        stage('Checkout') {
+            checkout scm
+            git.clean('')
+        }
+
+        stage('Build') {
+            mvn 'clean install -DskipTests'
+            archive '**/target/*.jar'
+        }
+
+        stage('Unit Test') {
+            mvn 'test'
+        }
+
+        stage('SonarQube') {
+            def branch = "${env.BRANCH_NAME}"
+
+            def scannerHome = tool name: 'sonar-scanner', type: 'hudson.plugins.sonar.SonarRunnerInstallation'
+            withSonarQubeEnv {
+                Git git = new Git(this, "cesmarvin")
+
+                sh "git config 'remote.origin.fetch' '+refs/heads/*:refs/remotes/origin/*'"
+                gitWithCredentials("fetch --all")
+
+                if (branch == "master") {
+                    echo "This branch has been detected as the main branch."
+                    sh "${scannerHome}/bin/sonar-scanner -Dsonar.projectKey=${projectName} -Dsonar.projectName=${projectName}"
+                } else if (branch == "develop") {
+                    echo "This branch has been detected as the develop branch."
+                    sh "${scannerHome}/bin/sonar-scanner -Dsonar.projectKey=${projectName} -Dsonar.projectName=${projectName} -Dsonar.branch.name=${env.BRANCH_NAME} -Dsonar.branch.target=master  "
+                } else if (env.CHANGE_TARGET) {
+                    echo "This branch has been detected as a pull request."
+                    sh "${scannerHome}/bin/sonar-scanner -Dsonar.projectKey=${projectName} -Dsonar.projectName=${projectName} -Dsonar.branch.name=${env.CHANGE_BRANCH}-PR${env.CHANGE_ID} -Dsonar.branch.target=${env.CHANGE_TARGET} "
+                } else if (branch.startsWith("feature/") || branch.startsWith("bugfix/")) {
+                    echo "This branch has been detected as a feature branch."
+                    sh "${scannerHome}/bin/sonar-scanner -Dsonar.projectKey=${projectName} -Dsonar.projectName=${projectName} -Dsonar.branch.name=${env.BRANCH_NAME} -Dsonar.branch.target=develop"
+                } else {
+                    echo "WARNING: This branch has not been detected. Assuming a feature branch."
+                    sh "${scannerHome}/bin/sonar-scanner -Dsonar.projectKey=${projectName} -Dsonar.projectName=${projectName} -Dsonar.branch.name=${env.BRANCH_NAME} -Dsonar.branch.target=develop"
+                }
+            }
+            timeout(time: 2, unit: 'MINUTES') { // Needed when there is no webhook for example
+                def qGate = waitForQualityGate()
+                if (qGate.status != 'OK') {
+                    unstable("Pipeline unstable due to SonarQube quality gate failure")
+                }
+            }
+        }
+    }
+}
+
+String repositoryOwner
+String projectName
+String projectPath
+String githubCredentialsId
+
+void gitWithCredentials(String command) {
+    withCredentials([usernamePassword(credentialsId: 'cesmarvin', usernameVariable: 'GIT_AUTH_USR', passwordVariable: 'GIT_AUTH_PSW')]) {
+        sh(
+                script: "git -c credential.helper=\"!f() { echo username='\$GIT_AUTH_USR'; echo password='\$GIT_AUTH_PSW'; }; f\" " + command,
+                returnStdout: true
+        )
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,9 @@ node() {
 
             stage('Unit Test') {
                 mvn 'test'
+
+                // Archive Unit and integration test results, if any
+                junit allowEmptyResults: true, testResults: '**/target/failsafe-reports/TEST-*.xml,**/target/surefire-reports/TEST-*.xml'
             }
         }
 
@@ -45,9 +48,6 @@ node() {
             }
         }
     }
-
-    // Archive Unit and integration test results, if any
-    junit allowEmptyResults: true, testResults: '**/target/failsafe-reports/TEST-*.xml,**/target/surefire-reports/TEST-*.xml'
 }
 
 def setupMaven(mvn) {

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>17.0</version>
+            <version>[30.0-jre,)</version>
         </dependency>
 
         <dependency>

--- a/sonar-home/conf/sonar.properties
+++ b/sonar-home/conf/sonar.properties
@@ -375,8 +375,9 @@ sonar.cas.casServerUrlPrefix = https://cas.hitchhiker.com:8443/cas
 sonar.cas.casServerLoginUrl = https://cas.hitchhiker.com:8443/cas/login
 # mandatory CAS server logout URL. If set, sonar session will be deleted on CAS logout request. Also from the logout-button
 sonar.cas.casServerLogoutUrl = https://cas.hitchhiker.com:8443/cas/logout
+# the server URL must contain the schema, like http or https.
 sonar.cas.sonarServerUrl = http://sonar.hitchhiker.com:9000/sonar
-# Sets the expiration time for the cooke. An integer specifying the maximum age of the cookie in seconds;
+# Sets the expiration time for the cookie. An integer specifying the maximum age of the cookie in seconds;
 # if negative, means the cookie is only stored until the browser exits; if zero, deletes the cookie
 sonar.cas.urlAfterCasRedirectCookieMaxAgeSeconds = 300
 # Mandatory: Stores the path to the volume where session blacklists/whitelists are persistently stored. This store must

--- a/sonar-home/conf/sonar.properties
+++ b/sonar-home/conf/sonar.properties
@@ -362,29 +362,27 @@ sonar.log.level.web=DEBUG
 # seems not to work, because of html push instead of real load?
 # authentication filter is not triggered, we have to use sonar.cas.forceCasLogin
 #sonar.forceAuthentication = true
-
 # disable SSL certificate validation
 # sonar.cas.disableCertValidation = true
-
-sonar.security.realm = cas
-
-sonar.authenticator.createUsers = true
-sonar.cas.forceCasLogin = true
-sonar.cas.protocol = cas3
-sonar.cas.casServerUrlPrefix = https://cas.hitchhiker.com:8443/cas
-sonar.cas.casServerLoginUrl = https://cas.hitchhiker.com:8443/cas/login
+sonar.security.realm=cas
+sonar.authenticator.createUsers=true
+sonar.cas.forceCasLogin=true
+sonar.cas.protocol=cas3
+sonar.cas.casServerUrlPrefix=https://cas.hitchhiker.com:8443/cas
+sonar.cas.casServerLoginUrl=https://cas.hitchhiker.com:8443/cas/login
 # mandatory CAS server logout URL. If set, sonar session will be deleted on CAS logout request. Also from the logout-button
-sonar.cas.casServerLogoutUrl = https://cas.hitchhiker.com:8443/cas/logout
+sonar.cas.casServerLogoutUrl=https://cas.hitchhiker.com:8443/cas/logout
 # the server URL must contain the schema, like http or https.
-sonar.cas.sonarServerUrl = http://sonar.hitchhiker.com:9000/sonar
+sonar.cas.sonarServerUrl=http://sonar.hitchhiker.com:9000/sonar
 # Sets the expiration time for the cookie. An integer specifying the maximum age of the cookie in seconds;
 # if negative, means the cookie is only stored until the browser exits; if zero, deletes the cookie
-sonar.cas.urlAfterCasRedirectCookieMaxAgeSeconds = 300
+sonar.cas.urlAfterCasRedirectCookieMaxAgeSeconds=300
+sonar.cas.userSecureRedirectCookies=true
 # Mandatory: Stores the path to the volume where session blacklists/whitelists are persistently stored. This store must
 # be persistent across server or container restarts or even container recreations in order to properly handle issued
 # authentications. Administrators may want to mount this as its own volume in order to scale with number of unexpired
 # sessions.
-sonar.cas.sessionStorePath = /opt/sonarqube/data/sonarcas/sessionstore
+sonar.cas.sessionStorePath=/opt/sonarqube/data/sonarcas/sessionstore
 # The CAS session store stores JWT tokens which have an expiration date. These are kept for black- and whitelisting
 # JWTs from a user in order to prohibit attackers which gained access to a user's old JWT tokens.
 # Once these JWTs are expired they need to be removed from the store in a background job. This property defines the

--- a/src/main/java/org/sonar/plugins/cas/CasIdentityProvider.java
+++ b/src/main/java/org/sonar/plugins/cas/CasIdentityProvider.java
@@ -45,7 +45,6 @@ import javax.servlet.http.HttpServletRequest;
 public class CasIdentityProvider implements BaseIdentityProvider {
 
     private static final Logger LOG = LoggerFactory.getLogger(CasIdentityProvider.class);
-    private static final String PROXY_TICKET_URL_SUFFIX = "/sessions/cas/proxy";
 
     private final Configuration configuration;
     private final LoginHandler loginHandler;

--- a/src/main/java/org/sonar/plugins/cas/CasRestClient.java
+++ b/src/main/java/org/sonar/plugins/cas/CasRestClient.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.plugins.cas;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,6 +29,7 @@ import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Client for the CAS REST API.
@@ -131,7 +131,7 @@ public class CasRestClient {
 
     private BufferedReader createReader(HttpURLConnection connection) throws IOException {
         InputStream stream = connection.getInputStream();
-        InputStreamReader in = new InputStreamReader(stream, Charsets.UTF_8);
+        InputStreamReader in = new InputStreamReader(stream, StandardCharsets.UTF_8);
         return new BufferedReader(in);
     }
 
@@ -180,7 +180,7 @@ public class CasRestClient {
 
     private BufferedWriter createWriter(HttpURLConnection connection) throws IOException {
         OutputStream stream = connection.getOutputStream();
-        OutputStreamWriter out = new OutputStreamWriter(stream, Charsets.UTF_8);
+        OutputStreamWriter out = new OutputStreamWriter(stream, StandardCharsets.UTF_8);
         return new BufferedWriter(out);
     }
 

--- a/src/main/java/org/sonar/plugins/cas/ForceCasLoginFilter.java
+++ b/src/main/java/org/sonar/plugins/cas/ForceCasLoginFilter.java
@@ -86,7 +86,7 @@ public class ForceCasLoginFilter extends ServletFilter {
 
             if (logoutHandler.isUserLoggedOutAndLogsInAgain(request)) {
                 LOG.debug("Redirecting logged-out user to log-in page");
-                HttpStreams.saveRequestedURLInCookie(request, response, maxRedirectCookieAge);
+                HttpStreams.saveRequestedURLInCookie(request, response, maxRedirectCookieAge, configuration);
                 logoutHandler.handleInvalidJwtCookie(request, response);
                 redirectToLogin(request, response);
             } else {
@@ -97,7 +97,7 @@ public class ForceCasLoginFilter extends ServletFilter {
             LOG.debug("Found unauthenticated request or request not in whitelist: {}. Redirecting to login page",
                     requestedURL);
             // keep the original URL during redirectToLogin to the CAS server in order to have the URL opened as intended by the user
-            HttpStreams.saveRequestedURLInCookie(request, response, maxRedirectCookieAge);
+            HttpStreams.saveRequestedURLInCookie(request, response, maxRedirectCookieAge, configuration);
             redirectToLogin(request, response);
         }
     }

--- a/src/main/java/org/sonar/plugins/cas/LoginHandler.java
+++ b/src/main/java/org/sonar/plugins/cas/LoginHandler.java
@@ -129,7 +129,9 @@ public class LoginHandler {
         if (StringUtils.isBlank(contextPath)) {
             contextPath = "/";
         }
-        Cookie cookie = Cookies.createDeletionCookie(COOKIE_NAME_URL_AFTER_CAS_REDIRECT, contextPath);
+        boolean useSecureCookies = SonarCasProperties.USE_SECURE_REDIRECT_COOKIES.getBoolean(configuration, true);
+
+        Cookie cookie = Cookies.createDeletionCookie(COOKIE_NAME_URL_AFTER_CAS_REDIRECT, contextPath, useSecureCookies);
 
         response.addCookie(cookie);
     }

--- a/src/main/java/org/sonar/plugins/cas/logout/LogoutHandler.java
+++ b/src/main/java/org/sonar/plugins/cas/logout/LogoutHandler.java
@@ -128,10 +128,12 @@ public class LogoutHandler {
     }
 
     private void removeAuthCookies(HttpServletResponse response, String contextPath) {
-        Cookie jwtCookie = Cookies.createDeletionCookie(JWT_SESSION_COOKIE, contextPath);
+        boolean useSecureCookies = SonarCasProperties.USE_SECURE_REDIRECT_COOKIES.getBoolean(configuration, true);
+
+        Cookie jwtCookie = Cookies.createDeletionCookie(JWT_SESSION_COOKIE, contextPath, useSecureCookies);
         response.addCookie(jwtCookie);
 
-        Cookie xsrfCookie = Cookies.createDeletionCookie("XSRF-TOKEN", contextPath);
+        Cookie xsrfCookie = Cookies.createDeletionCookie("XSRF-TOKEN", contextPath, useSecureCookies);
         response.addCookie(xsrfCookie);
     }
 

--- a/src/main/java/org/sonar/plugins/cas/util/Cookies.java
+++ b/src/main/java/org/sonar/plugins/cas/util/Cookies.java
@@ -18,9 +18,10 @@ public final class Cookies {
      *
      * @param cookieName the cookie name identifies the cookie to be deleted. Must not be <code>null</code> or the
      *                   empty string.
+     * @param secure     toggle this boolean flag to secure so the cookie must be sent over HTTPS
      * @return a new cookie which is supposed to be deleted by the browser
      */
-    public static Cookie createDeletionCookie(String cookieName, String contextPath) {
+    public static Cookie createDeletionCookie(String cookieName, String contextPath, boolean secure) {
         if (StringUtils.isEmpty(cookieName)) {
             throw new IllegalArgumentException("Could not create cookie. CookieName must not be empty.");
         }
@@ -30,7 +31,7 @@ public final class Cookies {
                 .value("")
                 .contextPath(contextPath)
                 .maxAgeInSecs(0)
-                .secure(true)
+                .secure(secure)
                 .build();
     }
 

--- a/src/main/java/org/sonar/plugins/cas/util/Cookies.java
+++ b/src/main/java/org/sonar/plugins/cas/util/Cookies.java
@@ -30,6 +30,7 @@ public final class Cookies {
                 .value("")
                 .contextPath(contextPath)
                 .maxAgeInSecs(0)
+                .secure(true)
                 .build();
     }
 
@@ -65,6 +66,7 @@ public final class Cookies {
         private String value;
         private String contextPath;
         private int maxAge;
+        private boolean secure;
 
         /**
          * @param name the name identifies uniquely a cookie. Must not be empty.
@@ -101,6 +103,16 @@ public final class Cookies {
             return this;
         }
 
+        /**
+         * @param secureCookie When a cookie is protected with the secure attribute set to true it will not be sent by
+         *                     the browser over an unencrypted HTTP request and thus cannot be observed by an
+         *                     unauthorized person during a man-in-the-middle attack
+         */
+        public HttpOnlyCookieBuilder secure(boolean secureCookie) {
+            this.secure = secureCookie;
+            return this;
+        }
+
         public Cookie build() {
             if (StringUtils.isEmpty(name)) {
                 throw new IllegalArgumentException("Could not create cookie. Cookie name must not be empty.");
@@ -115,6 +127,7 @@ public final class Cookies {
             Cookie cookie = new Cookie(name, value);
             cookie.setMaxAge(maxAge);
             cookie.setPath(contextPath);
+            cookie.setSecure(secure);
             cookie.setHttpOnly(true);
 
             return cookie;

--- a/src/main/java/org/sonar/plugins/cas/util/HttpStreams.java
+++ b/src/main/java/org/sonar/plugins/cas/util/HttpStreams.java
@@ -24,6 +24,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sonar.api.config.Configuration;
 
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -89,29 +90,45 @@ public final class HttpStreams {
     /**
      * Keep the original URL during redirectToLogin to the CAS server in order to have the URL opened as intended by the
      * user.
-     * @param request the request is used to get the original URL and query parameters
+     *
+     * @param request  the request is used to get the original URL and query parameters
      * @param response the response is used to save a cookie containing the original URL
+     * @param config   the SonarQube config object which contains instance specific configuration values from the <pre>sonar.properties</pre> file.
      */
-    public static void saveRequestedURLInCookie(HttpServletRequest request, HttpServletResponse response, int maxCookieAge) {
+    public static void saveRequestedURLInCookie(HttpServletRequest request, HttpServletResponse response, int maxCookieAge, Configuration config) {
+        String configSonarURL = SonarCasProperties.SONAR_SERVER_URL.mustGetString(config);
         String originalURL = HttpStreams.getRequestUrlWithQueryParameters(request);
         String contextPath = request.getContextPath();
 
-        if(StringUtils.isBlank(contextPath)){
+        String redirectAfterCasLoginURL = replaceSchema(configSonarURL, originalURL);
+
+        if (StringUtils.isBlank(contextPath)) {
             contextPath = "/";
         }
 
-        LOG.debug("found original URL {}", originalURL);
-        LOG.debug("using context path {}", contextPath);
-
+        LOG.debug("Redirect to URL after CAS login {}", redirectAfterCasLoginURL);
+        LOG.debug("Using context path {}", contextPath);
 
         Cookie cookie = new Cookies.HttpOnlyCookieBuilder()
                 .name(COOKIE_NAME_URL_AFTER_CAS_REDIRECT)
-                .value(originalURL)
+                .value(redirectAfterCasLoginURL)
                 .maxAgeInSecs(maxCookieAge)
                 .contextPath(contextPath)
                 .build();
 
         LOG.debug("set cookie with context path {}", contextPath);
         response.addCookie(cookie);
+    }
+
+    static String replaceSchema(String configSonarURL, String originalURL) {
+        int schemaIndex = configSonarURL.indexOf("://");
+        if (schemaIndex == -1) {
+            throw new SonarCasProperties.SonarCasPropertyMisconfigurationException(
+                    SonarCasProperties.SONAR_SERVER_URL.propertyKey,
+                    "must contain a schema, like http or https.");
+        }
+
+        String schema = configSonarURL.substring(0, schemaIndex);
+        return originalURL.replaceFirst("https?", schema);
     }
 }

--- a/src/main/java/org/sonar/plugins/cas/util/HttpStreams.java
+++ b/src/main/java/org/sonar/plugins/cas/util/HttpStreams.java
@@ -108,12 +108,14 @@ public final class HttpStreams {
 
         LOG.debug("Redirect to URL after CAS login {}", redirectAfterCasLoginURL);
         LOG.debug("Using context path {}", contextPath);
+        boolean secureCookie = SonarCasProperties.USE_SECURE_REDIRECT_COOKIES.getBoolean(config, true);
 
         Cookie cookie = new Cookies.HttpOnlyCookieBuilder()
                 .name(COOKIE_NAME_URL_AFTER_CAS_REDIRECT)
                 .value(redirectAfterCasLoginURL)
                 .maxAgeInSecs(maxCookieAge)
                 .contextPath(contextPath)
+                .secure(secureCookie)
                 .build();
 
         LOG.debug("set cookie with context path {}", contextPath);

--- a/src/main/java/org/sonar/plugins/cas/util/JwtFiles.java
+++ b/src/main/java/org/sonar/plugins/cas/util/JwtFiles.java
@@ -83,6 +83,8 @@ public final class JwtFiles {
 
         try {
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
             transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             Transformer transformer = transformerFactory.newTransformer();
 

--- a/src/main/java/org/sonar/plugins/cas/util/SonarCasProperties.java
+++ b/src/main/java/org/sonar/plugins/cas/util/SonarCasProperties.java
@@ -233,4 +233,10 @@ public enum SonarCasProperties {
             super("Could not find Sonar property with key " + propertyKey + " when it was expected to be configured.");
         }
     }
+
+    static class SonarCasPropertyMisconfigurationException extends RuntimeException {
+        SonarCasPropertyMisconfigurationException(String propertyKey, String misconfigReason) {
+            super("SonarQube property with key " + propertyKey + " is misconfigured: " + misconfigReason);
+        }
+    }
 }

--- a/src/main/java/org/sonar/plugins/cas/util/SonarCasProperties.java
+++ b/src/main/java/org/sonar/plugins/cas/util/SonarCasProperties.java
@@ -28,7 +28,7 @@ import org.sonar.api.config.Configuration;
  */
 public enum SonarCasProperties {
     /**
-     * Should SONAR create new users? Must be set to TRUE.
+     * Should SonarQube create new users? Must be set to TRUE.
      */
     SONAR_CREATE_USERS("sonar.authenticator.createUsers", SonarPropertyType.BOOLEAN),
     /**
@@ -49,7 +49,7 @@ public enum SonarCasProperties {
     CAS_SERVER_URL_PREFIX("sonar.cas.casServerUrlPrefix", SonarPropertyType.STRING),
     /**
      * Specifies how SonarQube groups should be replicated.
-
+     *
      * <p>A value of <code>CAS</code> always overwrites the user's
      * local groups with the group provided by CAS upon UI log-in. The user's local groups will be untouched with other
      * values.</p>
@@ -92,6 +92,13 @@ public enum SonarCasProperties {
      * Ignore certification validation errors. CAUTION! NEVER USE IN PROD! SECURITY RISK!
      */
     DISABLE_CERT_VALIDATION("sonar.cas.disableCertValidation", SonarPropertyType.BOOLEAN),
+    /**
+     * This value determines whether a Redirect Cookie after the CAS login uses the Secure-flag. Cookies with
+     * <code>secure=true</code> will only work properly in conjunction with HTTPS.
+     *
+     * <p>default to <code>true</code></p>
+     */
+    USE_SECURE_REDIRECT_COOKIES("sonar.cas.userSecureRedirectCookies", SonarPropertyType.BOOLEAN),
     /**
      * The expiration time of the cookie which helps to restore the originally requested SonarQube URL over the CAS authentication
      */

--- a/src/main/java/org/sonar/plugins/cas/util/SonarCasProperties.java
+++ b/src/main/java/org/sonar/plugins/cas/util/SonarCasProperties.java
@@ -136,7 +136,7 @@ public enum SonarCasProperties {
     }
 
     /**
-     * Returns a configuration value as string if the key was configured. Otherwise a {@link CasPropertyNotFoundException} is
+     * Returns a configuration value as string if the key was configured. Otherwise a {@link SonarCasPropertyNotFoundException} is
      * thrown.
      *
      * @param config the SonarQube configuration object holds all configured properties
@@ -145,7 +145,7 @@ public enum SonarCasProperties {
     public String mustGetString(Configuration config) {
         assertPropertyType(SonarPropertyType.STRING);
 
-        return config.get(propertyKey).orElseThrow(() -> new CasPropertyNotFoundException(propertyKey));
+        return config.get(propertyKey).orElseThrow(() -> new SonarCasPropertyNotFoundException(propertyKey));
     }
 
     /**
@@ -161,7 +161,7 @@ public enum SonarCasProperties {
     }
 
     /**
-     * Returns a configuration value as boolean if the key was configured. Otherwise a {@link CasPropertyNotFoundException} is
+     * Returns a configuration value as boolean if the key was configured. Otherwise a {@link SonarCasPropertyNotFoundException} is
      * thrown.
      *
      * @param config the SonarQube configuration object holds all configured properties
@@ -170,7 +170,7 @@ public enum SonarCasProperties {
     public boolean mustGetBoolean(Configuration config) {
         assertPropertyType(SonarPropertyType.BOOLEAN);
 
-        return config.getBoolean(propertyKey).orElseThrow(() -> new CasPropertyNotFoundException(propertyKey));
+        return config.getBoolean(propertyKey).orElseThrow(() -> new SonarCasPropertyNotFoundException(propertyKey));
     }
 
     /**
@@ -187,7 +187,7 @@ public enum SonarCasProperties {
     }
 
     /**
-     * Returns a configuration value as integer if the key was configured. Otherwise a {@link CasPropertyNotFoundException} is
+     * Returns a configuration value as integer if the key was configured. Otherwise a {@link SonarCasPropertyNotFoundException} is
      * thrown.
      *
      * @param config the SonarQube configuration object holds all configured properties
@@ -196,7 +196,7 @@ public enum SonarCasProperties {
     public int mustGetInteger(Configuration config) {
         assertPropertyType(SonarPropertyType.INTEGER);
 
-        return config.getInt(propertyKey).orElseThrow(() -> new CasPropertyNotFoundException(propertyKey));
+        return config.getInt(propertyKey).orElseThrow(() -> new SonarCasPropertyNotFoundException(propertyKey));
     }
 
     /**
@@ -228,9 +228,9 @@ public enum SonarCasProperties {
         INTEGER
     }
 
-    private static class CasPropertyNotFoundException extends RuntimeException {
-        CasPropertyNotFoundException(String propertyKey) {
-            super("Could not find Sonar property with key " + propertyKey + " when it was expected to be configured.");
+    private static class SonarCasPropertyNotFoundException extends RuntimeException {
+        SonarCasPropertyNotFoundException(String propertyKey) {
+            super("Could not find SonarQube property with key " + propertyKey + " when it was expected to be configured.");
         }
     }
 

--- a/src/main/java/org/sonar/plugins/cas/util/XMLParsing.java
+++ b/src/main/java/org/sonar/plugins/cas/util/XMLParsing.java
@@ -17,6 +17,11 @@ public class XMLParsing {
 
     public static DocumentBuilder createSecureBuilder() throws ParserConfigurationException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         return factory.newDocumentBuilder();
     }

--- a/src/test/java/org/sonar/plugins/cas/ForceCasLoginFilterTest.java
+++ b/src/test/java/org/sonar/plugins/cas/ForceCasLoginFilterTest.java
@@ -28,7 +28,8 @@ public class ForceCasLoginFilterTest {
     public void doFilterShouldHandleGetResource_alreadyLoggedIn() throws IOException, ServletException {
         Configuration config = new SonarTestConfiguration()
                 .withAttribute("sonar.cas.sessionStorePath", "/tmp")
-                .withAttribute("sonar.cas.urlAfterCasRedirectCookieMaxAgeSeconds", "300");
+                .withAttribute("sonar.cas.urlAfterCasRedirectCookieMaxAgeSeconds", "300")
+                .withAttribute("sonar.cas.sonarServerUrl", "http://sonar.com/sonar");
         CasSessionStoreFactory sessionStoreFactory = new CasSessionStoreFactory(config);
         LogoutHandler logoutHandler = new LogoutHandler(config, sessionStoreFactory);
         ForceCasLoginFilter sut = new ForceCasLoginFilter(config, logoutHandler);
@@ -72,7 +73,8 @@ public class ForceCasLoginFilterTest {
         // given
         Configuration config = new SonarTestConfiguration()
                 .withAttribute("sonar.cas.sessionStorePath", "/tmp")
-                .withAttribute("sonar.cas.urlAfterCasRedirectCookieMaxAgeSeconds", "100");
+                .withAttribute("sonar.cas.urlAfterCasRedirectCookieMaxAgeSeconds", "100")
+                .withAttribute("sonar.cas.sonarServerUrl", "http://sonar.com/sonar");
         CasSessionStoreFactory sessionStoreFactory = new CasSessionStoreFactory(config);
         LogoutHandler logoutHandler = new LogoutHandler(config, sessionStoreFactory);
         ForceCasLoginFilter sut = new ForceCasLoginFilter(config, logoutHandler);

--- a/src/test/java/org/sonar/plugins/cas/LoginHandlerTest.java
+++ b/src/test/java/org/sonar/plugins/cas/LoginHandlerTest.java
@@ -8,6 +8,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Mockito.*;
+import static org.sonar.plugins.cas.LoginHandler.getTicketParameter;
 
 public class LoginHandlerTest {
     @Test
@@ -18,10 +19,9 @@ public class LoginHandlerTest {
         CasSessionStore sessionStore = mock(CasSessionStore.class);
         CasSessionStoreFactory sessionStoreFactory = mock(CasSessionStoreFactory.class);
         when(sessionStoreFactory.getInstance()).thenReturn(sessionStore);
-        LoginHandler sut = new LoginHandler(null, null, sessionStoreFactory, null);
 
         // when
-        String actual = sut.getTicketParameter(request);
+        String actual = getTicketParameter(request);
 
         // then
         assertThat(actual).isEqualTo("");
@@ -37,10 +37,9 @@ public class LoginHandlerTest {
         CasSessionStore sessionStore = mock(CasSessionStore.class);
         CasSessionStoreFactory sessionStoreFactory = mock(CasSessionStoreFactory.class);
         when(sessionStoreFactory.getInstance()).thenReturn(sessionStore);
-        LoginHandler sut = new LoginHandler(null, null, sessionStoreFactory, null);
 
         // when
-        String actual = sut.getTicketParameter(request);
+        String actual = getTicketParameter(request);
 
         // then
         assertThat(actual).isEqualTo("ST-012345678");

--- a/src/test/java/org/sonar/plugins/cas/util/CookiesTest.java
+++ b/src/test/java/org/sonar/plugins/cas/util/CookiesTest.java
@@ -29,7 +29,7 @@ public class CookiesTest {
 
     @Test
     public void createDeletionCookie() {
-        Cookie cookie = Cookies.createDeletionCookie("key", "http://server.url/");
+        Cookie cookie = Cookies.createDeletionCookie("key", "http://server.url/", true);
 
         assertThat(cookie.getName()).isEqualTo("key");
         assertThat(cookie.getValue()).isEqualTo("");
@@ -37,11 +37,15 @@ public class CookiesTest {
         assertThat(cookie.isHttpOnly()).isTrue();
         assertThat(cookie.getMaxAge()).isEqualTo(0);
         assertThat(cookie.getSecure()).isTrue();
+
+        Cookie cookie2 = Cookies.createDeletionCookie("key", "http://server.url/", false);
+
+        assertThat(cookie2.getSecure()).isFalse();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void createDeletionCookieShouldThrowException() {
-        Cookies.createDeletionCookie("key", null);
+        Cookies.createDeletionCookie("key", null, true);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/org/sonar/plugins/cas/util/CookiesTest.java
+++ b/src/test/java/org/sonar/plugins/cas/util/CookiesTest.java
@@ -16,6 +16,7 @@ public class CookiesTest {
                 .value("value")
                 .contextPath("/")
                 .maxAgeInSecs(3600)
+                .secure(true)
                 .build();
 
         assertThat(cookie.getName()).isEqualTo("key");
@@ -23,6 +24,7 @@ public class CookiesTest {
         assertThat(cookie.getPath()).isEqualTo("/");
         assertThat(cookie.isHttpOnly()).isTrue();
         assertThat(cookie.getMaxAge()).isEqualTo(3600);
+        assertThat(cookie.getSecure()).isTrue();
     }
 
     @Test
@@ -34,6 +36,7 @@ public class CookiesTest {
         assertThat(cookie.getPath()).isEqualTo("http://server.url/");
         assertThat(cookie.isHttpOnly()).isTrue();
         assertThat(cookie.getMaxAge()).isEqualTo(0);
+        assertThat(cookie.getSecure()).isTrue();
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/org/sonar/plugins/cas/util/HttpStreamsTest.java
+++ b/src/test/java/org/sonar/plugins/cas/util/HttpStreamsTest.java
@@ -19,12 +19,20 @@
  */
 package org.sonar.plugins.cas.util;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.junit.Test;
+import org.sonar.api.config.Configuration;
+import org.sonar.plugins.cas.SonarTestConfiguration;
 
+import javax.servlet.ServletOutputStream;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.Locale;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.*;
@@ -97,15 +105,17 @@ public class HttpStreamsTest {
     @Test
     public void saveRequestedURLInCookieShouldSaveWholeURLInCookie() {
         HttpServletRequest request = mock(HttpServletRequest.class);
-        String originalURL = "http://sonar.url.com/somePageWhichIsNotLogin";
+        String originalURL = "http://sonar.url.com/sonar/somePageWhichIsNotLogin";
         when(request.getRequestURL()).thenReturn(new StringBuffer(originalURL));
         when(request.getContextPath()).thenReturn("/sonar");
         // getRequestURL does NOT return query params. Kinda important for called sonar URLs
         when(request.getQueryString()).thenReturn("project=Das+&amp;Uuml;ber+Project&file=src/main/com/cloudogu/App.java");
+        Configuration config = new SonarTestConfiguration()
+                .withAttribute("sonar.cas.sonarServerUrl", "http://sonar.url.com/sonar");
 
         HttpServletResponse response = mock(HttpServletResponse.class);
 
-        HttpStreams.saveRequestedURLInCookie(request, response, 300);
+        HttpStreams.saveRequestedURLInCookie(request, response, 300, config);
 
         verify(request).getRequestURL();
         // Cookie is a crappy class that does not allow equals or hashcode, so we test the number of invocations of
@@ -114,6 +124,33 @@ public class HttpStreamsTest {
         verify(response).addCookie(any());
     }
 
+    @Test()
+    public void saveRequestedURLInCookieShouldReplaceSchemaFromSonarCasProperties() {
+        // In reverse-proxied systems (f. i. Cloudogu EcoSystem) the SonarQube-local scheme may differ from the global
+        // scheme. This is because SSL termination may be in place so that the URL looks like https://fqdn/sonar from a
+        // user's perspective, while SonarQube runs as http://localIP:port/sonar locally.
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        String originalURL = "http://sonar.url.com/sonar/somePageWhichIsNotLogin";
+        when(request.getRequestURL()).thenReturn(new StringBuffer(originalURL));
+        when(request.getContextPath()).thenReturn("/sonar");
+        // getRequestURL does NOT return query params. Kinda important for called sonar URLs
+        when(request.getQueryString()).thenReturn("project=Das+&amp;Uuml;ber+Project&file=src/main/com/cloudogu/App.java");
+        Configuration config = new SonarTestConfiguration()
+                .withAttribute("sonar.cas.sonarServerUrl", "https://sonar.url.com/sonar"); // different scheme than in the original URL
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        HttpStreams.saveRequestedURLInCookie(request, response, 300, config);
+
+        verify(request).getRequestURL();
+        // Cookie is a crappy class that does not allow equals or hashcode, so we test the number of invocations of
+        // getParameterMap. If it was only once, it would not have jumped into urlEncodeQueryParameters()
+        verify(request, times(2)).getQueryString();
+        assertThat(response.getCookie().getName()).isEqualTo(Cookies.COOKIE_NAME_URL_AFTER_CAS_REDIRECT);
+        assertThat(response.getCookie().getValue()).isEqualTo("https://sonar.url.com/sonar/somePageWhichIsNotLogin?project=Das+&amp;Uuml;ber+Project&file=src/main/com/cloudogu/App.java");
+        assertThat(response.getCookie().getMaxAge()).isEqualTo(300);
+        assertThat(response.getCookie().getPath()).isEqualTo("/sonar");
+    }
 
     @Test
     public void saveRequestedURLInCookieEmptyContext() {
@@ -123,15 +160,228 @@ public class HttpStreamsTest {
         when(request.getContextPath()).thenReturn("");
         // getRequestURL does NOT return query params. Kinda important for called sonar URLs
         when(request.getQueryString()).thenReturn("project=Das+&amp;Uuml;ber+Project&file=src/main/com/cloudogu/App.java");
+        Configuration config = new SonarTestConfiguration()
+                .withAttribute("sonar.cas.sonarServerUrl", "https://sonar.url.com/sonar");
 
         HttpServletResponse response = mock(HttpServletResponse.class);
 
-        HttpStreams.saveRequestedURLInCookie(request, response, 300);
+        HttpStreams.saveRequestedURLInCookie(request, response, 300, config);
 
         verify(request).getRequestURL();
         // Cookie is a crappy class that does not allow equals or hashcode, so we test the number of invocations of
         // getParameterMap. If it was only once, it would not have jumped into urlEncodeQueryParameters()
         verify(request, times(2)).getQueryString();
         verify(response).addCookie(any());
+    }
+
+    @Test
+    public void replaceSchemeShouldReplaceOnlySchemeFromURL() {
+        String configSonarURL = "https://my.server.com:9000/sonar";
+        String originalURL = "http://my.server.com:9000/sonar/project?key=value";
+
+        String actualURL = HttpStreams.replaceSchema(configSonarURL, originalURL);
+
+        assertThat(actualURL).isEqualTo("https://my.server.com:9000/sonar/project?key=value");
+    }
+
+    @Test(expected = SonarCasProperties.SonarCasPropertyMisconfigurationException.class)
+    public void replaceSchemeShouldThrowExceptionOnMissingSchema() {
+        String configSonarURL = "my.server.com:9000/sonar";
+        String originalURL = "http://my.server.com:9000/sonar/project?key=value";
+
+        HttpStreams.replaceSchema(configSonarURL, originalURL);
+    }
+
+    private static class MockHttpServletResponse implements HttpServletResponse {
+        private Cookie aSingleCookie;
+
+        Cookie getCookie() {
+            return aSingleCookie;
+        }
+
+        @Override
+        public void addCookie(Cookie cookie) {
+            aSingleCookie = cookie;
+        }
+
+        @Override
+        public boolean containsHeader(String name) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public String encodeURL(String url) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public String encodeRedirectURL(String url) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public String encodeUrl(String url) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public String encodeRedirectUrl(String url) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void sendError(int sc, String msg) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void sendError(int sc) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void sendRedirect(String location) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void setDateHeader(String name, long date) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void addDateHeader(String name, long date) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void setHeader(String name, String value) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void addHeader(String name, String value) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void setIntHeader(String name, int value) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void addIntHeader(String name, int value) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void setStatus(int sc, String sm) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public int getStatus() {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void setStatus(int sc) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public String getHeader(String name) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public Collection<String> getHeaders(String name) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public Collection<String> getHeaderNames() {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void setCharacterEncoding(String charset) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public String getContentType() {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void setContentType(String type) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public ServletOutputStream getOutputStream() {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public PrintWriter getWriter() {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void setContentLength(int len) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void setContentLengthLong(long length) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public int getBufferSize() {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void setBufferSize(int size) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void flushBuffer() {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void resetBuffer() {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public boolean isCommitted() {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void reset() {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public Locale getLocale() {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void setLocale(Locale loc) {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
This PR resolves #38 and replaces a possibly insecure HTTP request with a secure HTTPS one after the CAS login. The insecure HTTP request was introduced by picking an internal URL from a cookie instead of validating the URL via the Sonar.properties configuration.

Also this PR makes this repo finally arrive in year 2000 by adding a simple Jenkinsfile which builds, tests and SonarQube-analyzes the code.